### PR TITLE
Add support for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.*un~
+*.pyc
+.DS_Store
+demo/static/figure/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:4.2
+
+RUN adduser figure
+COPY . /home/figure/src
+RUN chown -R figure /home/figure/src
+USER figure
+WORKDIR /home/figure/src
+
+RUN npm install
+RUN npm install grunt-cli
+RUN $(npm bin)/grunt demo
+
+WORKDIR /home/figure/src/demo
+CMD ["python", "-m", "SimpleHTTPServer"]

--- a/README.md
+++ b/README.md
@@ -56,3 +56,8 @@ To update the figure.openmicroscopy.org site:
 
     - Copy the demo directory and replace the demo directory in gh-pages-staging branch.
     - Commit changes and open PR against ome/gh-pages-staging as described https://github.com/ome/figure/tree/gh-pages-staging
+
+It is also possible to run the demo in docker without installing anything locally:
+
+    $ docker build -t figure-demo .
+    $ docker run -ti --rm -p 8000:8000 figure-demo


### PR DESCRIPTION
This allowed testing https://github.com/ome/figure/pull/107 locally without installing anything (other than docker).
