### PR TITLE
Set DJANGO_SETTINGS_MODULE before the tests

### DIFF
--- a/.omeroci/app-build
+++ b/.omeroci/app-build
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e
-set -u
-set -x

--- a/setup.py
+++ b/setup.py
@@ -95,12 +95,13 @@ class PyTest(test_command):
     def run_tests(self):
         if self.test_pythonpath is not None:
             sys.path.insert(0, self.test_pythonpath)
+
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "omeroweb.settings")
+
         # import here, cause outside the eggs aren't loaded
         import pytest
         errno = pytest.main(self.test_args)
         sys.exit(errno)
-
-        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "omeroweb.settings")
 
         import django
         if django.VERSION > (1, 7):


### PR DESCRIPTION
Tested with:

```
git clone -b django_tests git://github.com/will-moore/figure omero-figure # name is important!
cd omero-figure
git clone git://github.com/openmicroscopy/omero-test-infra .omero # name is important!
.omero/docker app
```

I still had a few regular failures, but those are assertions for @will-moore to look at.